### PR TITLE
Added the boolean option "Enable Overriding Template World Settings",…

### DIFF
--- a/src/main/java/adubbz/lockdown/Lockdown.java
+++ b/src/main/java/adubbz/lockdown/Lockdown.java
@@ -26,7 +26,9 @@ public class Lockdown
     
     public static boolean disableMultiplayer;
     //public static boolean disableQuit;
-    
+
+    public static boolean enableOverridingTerrainGen;
+
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {
@@ -40,7 +42,8 @@ public class Lockdown
     		disableWorldCreation = config.get("World Creation", "Disable Regular World Creation", true).getBoolean(true);
     		disableGameMode = config.get("World Creation", "Disable Game Mode Button", true).getBoolean(true);
     		disableMoreWorldOptions = config.get("World Creation", "Disable More World Options Button", true).getBoolean(true);
-    		
+            enableOverridingTerrainGen = config.get("World Creation", "Enable Overriding Template World Settings", false).getBoolean(false);
+
     		disableMultiplayer = config.get("Main Menu", "Disable Multiplayer Button", true).getBoolean(true);
     		//disableQuit = config.get("Main Menu", "Disable Quit Button", true).getBoolean(true);
     	}

--- a/src/main/java/adubbz/lockdown/eventhandler/WorldCreationEventHandler.java
+++ b/src/main/java/adubbz/lockdown/eventhandler/WorldCreationEventHandler.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import adubbz.lockdown.gui.GuiCreateFixedWorld;
 import adubbz.lockdown.gui.GuiNonMultiplayerMainMenu;
+import adubbz.lockdown.Lockdown;
 import adubbz.lockdown.util.LDObfuscationHelper;
 import cpw.mods.fml.common.ObfuscationReflectionHelper;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;

--- a/src/main/java/adubbz/lockdown/gui/GuiCreateFixedWorld.java
+++ b/src/main/java/adubbz/lockdown/gui/GuiCreateFixedWorld.java
@@ -2,14 +2,22 @@ package adubbz.lockdown.gui;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Random;
 
+import cpw.mods.fml.relauncher.ReflectionHelper;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiCreateWorld;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.chunk.storage.AnvilSaveConverter;
 import net.minecraft.world.storage.ISaveFormat;
 
+import net.minecraft.world.storage.ISaveHandler;
+import net.minecraft.world.storage.WorldInfo;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 
@@ -64,6 +72,7 @@ public class GuiCreateFixedWorld extends GuiCreateWorld
             
             try
             {
+                LDLogger.log(Level.INFO, "Lockdown using template at " + Lockdown.templateDirectory);
             	FileUtils.copyDirectory(new File(mcDataDir.getAbsoluteFile() + File.separator + Lockdown.templateDirectory), new File(mcDataDir.getAbsoluteFile() + File.separator + "saves" + File.separator + folderName));
             }
             catch (IOException e)
@@ -74,10 +83,62 @@ public class GuiCreateFixedWorld extends GuiCreateWorld
             
             ISaveFormat isaveformat = this.mc.getSaveLoader();
             isaveformat.renameWorld(folderName, worldName);
-            
+
+            WorldSettings worldsettings = null;     // Default will just use the template's world settings.
+
+            if(Lockdown.enableOverridingTerrainGen)
+            {
+
+                // This mostly follows what a Vanilla instance would already do, excepting that we have to rip out all
+                // the private fields. We are going to populate worldsettings ourselves. One exception is we go out of
+                // our way to check that commands need to be enabled.
+                GuiTextField seedTextField = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146335_h");
+                String gameModeName = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146342_r");
+                boolean generateStructures = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146341_s");
+                boolean bonusChest = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146337_w");
+                boolean commandsAllowed = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146344_y");
+                int terrainType = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146331_K");
+
+                long defaultSeed = (new Random()).nextLong();
+                String seedText = seedTextField.getText();
+
+                if (!MathHelper.stringNullOrLengthZero(seedText))
+                {
+                    try
+                    {
+                        long j = Long.parseLong(seedText);
+
+                        if (j != 0L)
+                        {
+                            defaultSeed = j;
+                        }
+                    }
+                    catch (NumberFormatException numberformatexception)
+                    {
+                        defaultSeed = (long)seedText.hashCode();
+                    }
+                }
+
+                WorldSettings.GameType gametype = WorldSettings.GameType.getByName(gameModeName);
+                worldsettings = new WorldSettings(defaultSeed, gametype, generateStructures, bonusChest, WorldType.worldTypes[terrainType]);
+                worldsettings.func_82750_a(this.field_146334_a);
+
+                if(commandsAllowed)
+                {
+                    worldsettings.enableCommands();
+                }
+
+                // This normally happens once in the instance is started, but this code is skipped if a save already
+                // exists. We're going to flatten the copied save settings with the ones the user just defined.
+                WorldInfo worldinfo = new WorldInfo(worldsettings, folderName);
+                ISaveFormat saveLoader = new AnvilSaveConverter(new File(this.mc.mcDataDir, "saves"));
+                ISaveHandler isavehandler = saveLoader.getSaveLoader(folderName, false);
+                isavehandler.saveWorldInfo(worldinfo);
+            }
+
             if (this.mc.getSaveLoader().canLoadWorld(folderName))
             {
-                this.mc.launchIntegratedServer(folderName, worldName, (WorldSettings)null);
+                this.mc.launchIntegratedServer(folderName, worldName, worldsettings);
             }
     	}
     	else


### PR DESCRIPTION
… which

defaults to false, which operates just like previous versions. However, if set
to true, the user's specified world creation settings will override whatever was
in the original template.

This was desired by RockoBonaparte for his Baby's First Space Race modpack. The
plan was to start new users in a alternate tutorial dimension (DIM=2) using a
template. However, the Overworld had been deleted. There is a command block that
will send them to their Overworld spawn, and that Overworld is to be generated
dynamically based on the whatever settings the user gave when they created the
world.

Modpacks that want something like a "lobby dimension" on top of a regular game
would also take advantage of this.

The code targets 1.7, using the 1.7.2 codebase, which is compatible with 1.7.10.
