### PR TITLE
Override terrain gen 1.8

### DIFF
--- a/src/main/java/adubbz/lockdown/Lockdown.java
+++ b/src/main/java/adubbz/lockdown/Lockdown.java
@@ -26,7 +26,9 @@ public class Lockdown
     
     public static boolean disableMultiplayer;
     //public static boolean disableQuit;
-    
+
+    public static boolean enableOverridingTerrainGen;
+
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {
@@ -40,7 +42,8 @@ public class Lockdown
     		disableWorldCreation = config.get("World Creation", "Disable Regular World Creation", true).getBoolean(true);
     		disableGameMode = config.get("World Creation", "Disable Game Mode Button", true).getBoolean(true);
     		disableMoreWorldOptions = config.get("World Creation", "Disable More World Options Button", true).getBoolean(true);
-    		
+            enableOverridingTerrainGen = config.get("World Creation", "Enable Overriding Template World Settings", false).getBoolean(false);
+
     		disableMultiplayer = config.get("Main Menu", "Disable Multiplayer Button", true).getBoolean(true);
     		//disableQuit = config.get("Main Menu", "Disable Quit Button", true).getBoolean(true);
     	}

--- a/src/main/java/adubbz/lockdown/eventhandler/WorldCreationEventHandler.java
+++ b/src/main/java/adubbz/lockdown/eventhandler/WorldCreationEventHandler.java
@@ -9,6 +9,7 @@ import adubbz.lockdown.gui.GuiNonMultiplayerMainMenu;
 import adubbz.lockdown.util.LDObfuscationHelper;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import adubbz.lockdown.Lockdown;
 
 public class WorldCreationEventHandler 
 {

--- a/src/main/java/adubbz/lockdown/gui/GuiCreateFixedWorld.java
+++ b/src/main/java/adubbz/lockdown/gui/GuiCreateFixedWorld.java
@@ -128,9 +128,13 @@ public class GuiCreateFixedWorld extends GuiCreateWorld
 
                 // This normally happens once in the instance is started, but this code is skipped if a save already
                 // exists. We're going to flatten the copied save settings with the ones the user just defined.
-                WorldInfo worldinfo = new WorldInfo(worldsettings, folderName);
+                // However, we have to make sure it's JUST the world settings. We need to keep the player's coordinates,
+                // inventory, game mode, and whatever other miscellaneous junk.
                 ISaveFormat saveLoader = new AnvilSaveConverter(new File(this.mc.mcDataDir, "saves"));
                 ISaveHandler isavehandler = saveLoader.getSaveLoader(folderName, false);
+                WorldInfo worldinfo = isavehandler.loadWorldInfo();
+                worldinfo.populateFromWorldSettings(worldsettings);
+
                 isavehandler.saveWorldInfo(worldinfo);
             }
 

--- a/src/main/java/adubbz/lockdown/gui/GuiCreateFixedWorld.java
+++ b/src/main/java/adubbz/lockdown/gui/GuiCreateFixedWorld.java
@@ -2,15 +2,22 @@ package adubbz.lockdown.gui;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Random;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiCreateWorld;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.chunk.storage.AnvilSaveConverter;
 import net.minecraft.world.storage.ISaveFormat;
 
+import net.minecraft.world.storage.ISaveHandler;
+import net.minecraft.world.storage.WorldInfo;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 
 import adubbz.lockdown.Lockdown;
@@ -74,10 +81,62 @@ public class GuiCreateFixedWorld extends GuiCreateWorld
             
             ISaveFormat isaveformat = this.mc.getSaveLoader();
             isaveformat.renameWorld(folderName, worldName);
-            
+
+            WorldSettings worldsettings = null;     // Default will just use the template's world settings.
+
+            if(Lockdown.enableOverridingTerrainGen)
+            {
+
+                // This mostly follows what a Vanilla instance would already do, excepting that we have to rip out all
+                // the private fields. We are going to populate worldsettings ourselves. One exception is we go out of
+                // our way to check that commands need to be enabled.
+                GuiTextField seedTextField = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146335_h");
+                String gameModeName = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146342_r");
+                boolean generateStructures = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146341_s");
+                boolean bonusChest = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146337_w");
+                boolean commandsAllowed = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146344_y");
+                int terrainType = ObfuscationReflectionHelper.getPrivateValue(GuiCreateWorld.class, this, "field_146331_K");
+
+                long defaultSeed = (new Random()).nextLong();
+                String seedText = seedTextField.getText();
+
+                if (!StringUtils.isEmpty(seedText))
+                {
+                    try
+                    {
+                        long j = Long.parseLong(seedText);
+
+                        if (j != 0L)
+                        {
+                            defaultSeed = j;
+                        }
+                    }
+                    catch (NumberFormatException numberformatexception)
+                    {
+                        defaultSeed = (long)seedText.hashCode();
+                    }
+                }
+
+                WorldSettings.GameType gametype = WorldSettings.GameType.getByName(gameModeName);
+                worldsettings = new WorldSettings(defaultSeed, gametype, generateStructures, bonusChest, WorldType.worldTypes[terrainType]);
+                worldsettings.setWorldName(this.field_146334_a);
+
+                if(commandsAllowed)
+                {
+                    worldsettings.enableCommands();
+                }
+
+                // This normally happens once in the instance is started, but this code is skipped if a save already
+                // exists. We're going to flatten the copied save settings with the ones the user just defined.
+                WorldInfo worldinfo = new WorldInfo(worldsettings, folderName);
+                ISaveFormat saveLoader = new AnvilSaveConverter(new File(this.mc.mcDataDir, "saves"));
+                ISaveHandler isavehandler = saveLoader.getSaveLoader(folderName, false);
+                isavehandler.saveWorldInfo(worldinfo);
+            }
+
             if (this.mc.getSaveLoader().canLoadWorld(folderName))
             {
-                this.mc.launchIntegratedServer(folderName, worldName, (WorldSettings)null);
+                this.mc.launchIntegratedServer(folderName, worldName, worldsettings);
             }
     	}
     	else


### PR DESCRIPTION
This patch enables overriding templates with new overworld generation settings. It will take what the user specifies in the world creation GUI and apply that to the overworld. Template creators still need to delete the region folder in the template so the overworld regenerates. The template should also save the player in another dimension.

This change allows HQM modpacks to put their players in something like a "lobby dimension." The first motivation for this was for the Baby's First Space Race modpack. This allows new players to spawn in a tutorial world where they can learn about the quest book and basic mechanics before getting flung into the overworld.

This change overrides terrain generation, but all other player settings should stay the same. Most importantly of these is it preserves the template player's dimension, coordinates, inventory, and game settings.
